### PR TITLE
Bugfix: effective entry date

### DIFF
--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -7,6 +7,7 @@ var validate = require('./../validate');
 
 var highLevelHeaderOverrides = ['serviceClassCode', 'companyDiscretionaryData', 'companyIdentification', 'standardEntryClassCode'];
 var highLevelControlOverrides = ['addendaCount', 'entryHash', 'totalDebit', 'totalCredit'];
+var yymmddRegex = /^[2-9][0-9](0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$/
 
 function Batch(options) {
 	this._entries = [];
@@ -36,7 +37,7 @@ function Batch(options) {
 
 	if(options.effectiveEntryDate) {
 		if (typeof options.effectiveEntryDate === 'string') {
-			const yymmddRegex = /^[2-9][0-9](0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$/
+		    // validate effectiveEntryDate to be a valid YYMMDD string
 			if (!yymmddRegex.test(options.effectiveEntryDate)) {
 				throw new Error('Invalid effectiveEntryDate, should be YYMMDD: ' + options.effectiveEntryDate)
 			}

--- a/lib/batch/index.js
+++ b/lib/batch/index.js
@@ -35,7 +35,15 @@ function Batch(options) {
 	}
 
 	if(options.effectiveEntryDate) {
-		this.header.effectiveEntryDate.value = utils.formatDate(options.effectiveEntryDate);
+		if (typeof options.effectiveEntryDate === 'string') {
+			const yymmddRegex = /^[2-9][0-9](0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$/
+			if (!yymmddRegex.test(options.effectiveEntryDate)) {
+				throw new Error('Invalid effectiveEntryDate, should be YYMMDD: ' + options.effectiveEntryDate)
+			}
+			this.header.effectiveEntryDate.value = options.effectiveEntryDate;
+		} else {
+			this.header.effectiveEntryDate.value = utils.formatDate(options.effectiveEntryDate);
+		}
 	}
 
 	if(options.originatingDFI) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nach2",
   "description": "nACH is a highly customizable Node.js module exposing a high & low-level API for generating ACH files for use within the ACH network",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "keywords": [
     "ACH",
     "file",

--- a/test/batch.js
+++ b/test/batch.js
@@ -1,10 +1,7 @@
 var chai     = require('chai')
   , _        = require('lodash')
   , expect   = chai.expect
-  , Entry  = require('../lib/entry')
-  , EntryAddenda  = require('../lib/entry-addenda')
-  , Batch  = require('../lib/batch')
-  , File   = require('../lib/file');
+  , Batch  = require('../lib/batch');
 
 describe('Batch', function(){
   
@@ -16,7 +13,7 @@ describe('Batch', function(){
         companyName: 'Test Firm',
         standardEntryClassCode: 'CCD',
         companyIdentification: '110000000',
-        companyEntryDescription: 'OP PAYYOUT',
+        companyEntryDescription: 'OP PAYOUT',
         companyDescriptiveDate: '12345',
         effectiveEntryDate: new Date(), // Date
         originatingDFI: '110000000',
@@ -33,7 +30,7 @@ describe('Batch', function(){
         companyName: 'Test Firm',
         standardEntryClassCode: 'CCD',
         companyIdentification: '110000000',
-        companyEntryDescription: 'OP PAYYOUT',
+        companyEntryDescription: 'OP PAYOUT',
         companyDescriptiveDate: '12345',
         effectiveEntryDate: '200907', // string with 6 characters
         originatingDFI: '110000000',
@@ -53,7 +50,7 @@ describe('Batch', function(){
           companyName: 'Test Firm',
           standardEntryClassCode: 'CCD',
           companyIdentification: '110000000',
-          companyEntryDescription: 'OP PAYYOUT',
+          companyEntryDescription: 'OP PAYOUT',
           companyDescriptiveDate: '12345',
           effectiveEntryDate: '2009079', // 6 characters
           originatingDFI: '110000000',
@@ -75,7 +72,7 @@ describe('Batch', function(){
           companyName: 'Test Firm',
           standardEntryClassCode: 'CCD',
           companyIdentification: '110000000',
-          companyEntryDescription: 'OP PAYYOUT',
+          companyEntryDescription: 'OP PAYOUT',
           companyDescriptiveDate: '12345',
           effectiveEntryDate: '121314', // not a valid date
           originatingDFI: '110000000',
@@ -87,7 +84,5 @@ describe('Batch', function(){
 
       expect(error.message).equal('Invalid effectiveEntryDate, should be YYMMDD: 121314');
     });
-    
-    
   });
 });

--- a/test/batch.js
+++ b/test/batch.js
@@ -1,0 +1,93 @@
+var chai     = require('chai')
+  , _        = require('lodash')
+  , expect   = chai.expect
+  , Entry  = require('../lib/entry')
+  , EntryAddenda  = require('../lib/entry-addenda')
+  , Batch  = require('../lib/batch')
+  , File   = require('../lib/file');
+
+describe('Batch', function(){
+  
+  describe('Create Batch', function(){
+    
+    it('should create a batch successfully', function(){
+      var batch = new Batch({
+        serviceClassCode: '225',
+        companyName: 'Test Firm',
+        standardEntryClassCode: 'CCD',
+        companyIdentification: '110000000',
+        companyEntryDescription: 'OP PAYYOUT',
+        companyDescriptiveDate: '12345',
+        effectiveEntryDate: new Date(), // Date
+        originatingDFI: '110000000',
+        originatorStatusCode: '1'
+      });
+      batch.generateString(function(string) {
+        console.log(string);
+      });
+    });
+
+    it('should create batch with effectiveEntryDate as a string successfully', function(){
+      var batch = new Batch({
+        serviceClassCode: '225',
+        companyName: 'Test Firm',
+        standardEntryClassCode: 'CCD',
+        companyIdentification: '110000000',
+        companyEntryDescription: 'OP PAYYOUT',
+        companyDescriptiveDate: '12345',
+        effectiveEntryDate: '200907', // string with 6 characters
+        originatingDFI: '110000000',
+        originatorStatusCode: '1'
+      });
+      batch.generateString(function(string) {
+        console.log(string);
+      });
+    });
+
+    it('should NOT create batch with invalid effectiveEntryDate', function(){
+      let error;
+      
+      try {
+        var batch = new Batch({
+          serviceClassCode: '225',
+          companyName: 'Test Firm',
+          standardEntryClassCode: 'CCD',
+          companyIdentification: '110000000',
+          companyEntryDescription: 'OP PAYYOUT',
+          companyDescriptiveDate: '12345',
+          effectiveEntryDate: '2009079', // 6 characters
+          originatingDFI: '110000000',
+          originatorStatusCode: '1'
+        });
+      } catch (err) {
+        error = err;
+      }
+      
+      expect(error.message).equal('Invalid effectiveEntryDate, should be YYMMDD: 2009079');
+    });
+
+    it('should NOT create batch with invalid effectiveEntryDate', function(){
+      let error;
+
+      try {
+        var batch = new Batch({
+          serviceClassCode: '225',
+          companyName: 'Test Firm',
+          standardEntryClassCode: 'CCD',
+          companyIdentification: '110000000',
+          companyEntryDescription: 'OP PAYYOUT',
+          companyDescriptiveDate: '12345',
+          effectiveEntryDate: '121314', // not a valid date
+          originatingDFI: '110000000',
+          originatorStatusCode: '1'
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.message).equal('Invalid effectiveEntryDate, should be YYMMDD: 121314');
+    });
+    
+    
+  });
+});

--- a/test/file.js
+++ b/test/file.js
@@ -1,0 +1,45 @@
+var chai     = require('chai')
+    , _        = require('lodash')
+    , expect   = chai.expect
+    , File  = require('../lib/file');
+
+describe('Batch', function() {
+
+    describe('Create File', function () {
+        it('should create a file successfully', function () {
+            const file = new File({
+                immediateDestination: '110000000', 
+                immediateOrigin: '110000000',
+                immediateDestinationName: 'SOME BANK',
+                immediateOriginName: 'SOME COMPANY',
+                referenceCode: 'ABCD',
+                priorityCode: '1',
+                fileIdModifier: 'A'
+            });
+            file.generateFile(function(string) {
+                console.log(string);
+            });
+        });
+
+        it('should overide fileCreationDate and fileCreationTime successfully', function () {
+            const file = new File({
+                immediateDestination: '110000000',
+                immediateOrigin: '110000000',
+                immediateDestinationName: 'SOME BANK',
+                immediateOriginName: 'SOME COMPANY',
+                referenceCode: 'ABCD',
+                priorityCode: '1',
+                fileIdModifier: 'A',
+                fileCreationDate: '190301',
+                fileCreationTime: '1212'
+            });
+            file.generateFile(function(string) {
+                console.log(string);
+                const lines = string.split('\n');
+                expect(lines[0]).contain('1903011212')
+            });
+        });
+    })
+})
+
+        


### PR DESCRIPTION
Bug description: 

- when you pass effectiveEntryDate as a Date object, this library does formatting of date in UTC timezone and that is not what you expect

Fix description:

- if effectiveEntryDate is provided as a string, and it's a valid YYMMDD string - use that effectiveEntryDate as is, without formatting

Also:

- added a test to ensure that you can override parameters fileCreationDate and fileCreationTime when create a File